### PR TITLE
Fixed conditional reveal.

### DIFF
--- a/app/models/MainServiceQuestion.scala
+++ b/app/models/MainServiceQuestion.scala
@@ -46,7 +46,7 @@ object MainServiceQuestion {
 
   def options(form: Form[_])(implicit messages: Messages): Seq[RadioItem] = values.map { value =>
     RadioItem(
-      id = Some(s"$baseMessageKey.${value.toString}"),
+      id = Some(s"$baseMessageKey-${value.toString}"),
       value = Some(value.toString),
       content = Text(messages(s"$baseMessageKey.$value")),
       checked = form(baseMessageKey).value.contains(value.toString)


### PR DESCRIPTION
It was really simple in the end, I replaced the full stop with a hyphen.

I'm going to take a deeper look into the reason behind this as it's perfectly valid to have a full stop in an HTML ID.  If hyphens work for you then this change can go straigh tinto your branch and I'll investigate to avoid other people hitting the same issue.  If you're really keen on having the full stop I'm hoping there'll be an update to fix the issue bet it's likely to be with GDS so it'll take some time to go through - maybe a week or two.